### PR TITLE
Sensu Classic Core sandbox with Slack, InfluxDB, and Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# sandbox
-The place to get started for new sensu users
+# Sensu Sandbox
+The place to get started for new Sensu users
+
+- [Get started with Sensu Classic Core](sensu-classic/core)
+- [Get started with Sensu Classic Enterprise](sensu-classic/enterprise)

--- a/sensu-classic/core/README.md
+++ b/sensu-classic/core/README.md
@@ -1,0 +1,842 @@
+### Welcome to the Sensu Core sandbox!
+
+This tutorial will get you up and running with Sensu.
+
+- [Set up the sandbox](#set-up-the-sandbox)
+- [Lesson \#1: Create a monitoring event](#lesson-1-create-a-monitoring-event)
+- [Lesson \#2: Create an event pipeline](#lesson-2-pipe-events-into-slack)
+- [Lesson \#3: Automate event production with the Sensu client](#lesson-3-automate-event-production-with-the-sensu-client)
+
+We'd love to hear your feedback!
+While this sandbox is internal to Sensu, please add feedback to this [GoogleDoc](https://docs.google.com/document/d/1HSIkd3wO6ulAiya3aWB6MjCReYwLdkKIrY4_d4BkFfo/edit#).
+
+---
+
+## Set up the sandbox
+
+**1. Install Vagrant and VirtualBox:**
+
+- [Download Vagrant](https://www.vagrantup.com/downloads.html)
+- [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+
+**2. Download the sandbox:**
+
+[Download from GitHub](https://github.com/sensu/sandbox/archive/core.zip) or clone the repository:
+
+```
+git clone git@github.com:sensu/sandbox.git && cd sandbox && git checkout core
+```
+
+If you downloaded the zip file from GitHub, unzip the folder and move it into your Documents folder.
+Then open Terminal and enter `cd Documents` followed by `cd sandbox-core`.
+
+**3. Start Vagrant:**
+
+```
+cd sensu-classic/core && vagrant up
+```
+
+This will take around five minutes, so if you haven't already, [read about how Sensu works](https://docs.sensu.io/sensu-core/1.4/overview/architecture) or see the [appendix](#appendix) for details about the sandbox.
+
+**4. SSH into the sandbox:**
+
+Thanks for waiting! To start using the sandbox:
+
+```
+vagrant ssh
+```
+
+_NOTE: To exit out of the sandbox, use `CTRL`+`D`.
+Use `vagrant destroy` then `vagrant up` to erase and restart the sandbox._
+
+---
+
+## Lesson \#1: Create a monitoring event
+
+First off, we'll make sure everything is working correctly by creating a few events with the Sensu server and API.
+
+**1. Use the settings API to see Sensu's configuration:**
+
+```
+curl -s http://localhost:4567/settings | jq .
+```
+
+With the Sensu server, we can see that we have no active clients, and that Sensu is using RabbitMQ as the transport and Redis as the datastore.
+We can see a lot of this same information in the [dashboard datacenter view](http://172.31.255.4:3000/#/datacenters).
+
+```json
+$ curl -s http://localhost:4567/settings | jq .
+{
+  "client": {},
+  "sensu": {
+    "spawn": {
+      "limit": 12
+    },
+    "keepalives": {
+      "thresholds": {
+        "warning": 120,
+        "critical": 180
+      }
+    }
+  },
+  "transport": {
+    "name": "rabbitmq",
+    "reconnect_on_error": true
+  },
+  "checks": {},
+  "filters": {},
+  "mutators": {},
+  "handlers": {},
+  "extensions": {},
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5672,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "REDACTED",
+    "heartbeat": 30,
+    "prefetch": 50
+  },
+  "redis": {
+    "host": "127.0.0.1",
+    "port": 6379
+  }
+}
+```
+
+**2. Create an event that warns us that docs.sensu.io is loading slowly (and resolve it)**
+
+Let's say we have an application that can test the Sensu docs site and output a string with the response time.
+We can use the results API to create an event that represents a warning from our pseudo-app that the docs site is getting slow.
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Not great. Total time: x.xxx seconds.",
+  "status": 1
+}' \
+http://localhost:4567/results
+```
+
+Since we're creating this event using the API, Sensu doesn't know where this information is coming from, so we use the `source` attribute to tell Sensu that we're creating this event on behalf of a remote source.
+The `status` attribute represents a warning-level event (0 = OK, 1 = warning, 2 = critical),
+
+We can use the events API to see the resulting event:
+
+```
+curl -s http://localhost:4567/events | jq .
+```
+
+_NOTE: The events API returns only warning (`"status": 1`) and critical (`"status": 2`) events._
+
+Event data contains information about the part of your system the event came from (the `client` or `source`), the result of the check (including a `history` of recent `status` results), and the event itself (including the number of `occurrences`).
+
+In this example, the event data tells us that this is a warning-level alert (`"status": 1`) created while monitoring curl times on `docs.sensu.io`.
+We can also see the alert and the client in the [dashboard event view](http://172.31.255.4:3000/#/events) and [client view](http://172.31.255.4:3000/#/clients).
+
+```json
+$ curl -s http://localhost:4567/events | jq .
+[
+  {
+    "id": "188add2a-66aa-4fd8-aeed-bd16775e5f2d",
+    "client": {
+      "name": "docs.sensu.io",
+      "address": "unknown",
+      "subscriptions": [
+        "client:docs.sensu.io"
+      ],
+      "keepalives": false,
+      "version": "1.4.3",
+      "timestamp": 1533923797,
+      "type": "proxy"
+    },
+    "check": {
+      "source": "docs.sensu.io",
+      "name": "check_curl_timings",
+      "output": "Not great. Total time: x.xxx seconds.",
+      "status": 1,
+      "issued": 1533923797,
+      "executed": 1533923797,
+      "type": "standard",
+      "origin": "sensu-api",
+      "history": [
+        "1"
+      ],
+      "total_state_change": 0
+    },
+    "occurrences": 1,
+    "occurrences_watermark": 1,
+    "last_ok": null,
+    "action": "create",
+    "timestamp": 1533923797,
+    "last_state_change": 1533923797,
+    "silenced": false,
+    "silenced_by": []
+  }
+]
+```
+
+We created our first event!
+Now let's remove the warning from the dashboard by creating a resolution event:
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Nice! Total time: x.xxx seconds.",
+  "status": 0
+}' \
+http://localhost:4567/results
+```
+
+After a few seconds, we can check the [dashboard client view](http://172.31.255.4:3000/#/clients) and see that there are no active alerts and that the client is healthy.
+
+_NOTE: The dashboard auto-refreshes every 10 seconds._
+
+**3. Create a discovery event to provide context about the systems we're monitoring**
+
+This time, use the clients API to create an event that gives Sensu some extra information about docs.sensu.io:
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "name": "docs.sensu.io",
+  "address": "https://docs.sensu.io",
+  "playbook": "https://link-to-playbook.com"
+}' \
+http://localhost:4567/clients
+```
+
+You can see the new `environment` and `playbook` attributes in the [dashboard client view](http://172.31.255.4:3000/#/clients) or using the clients API:
+
+```
+curl -s http://localhost:4567/clients | jq .
+```
+
+```json
+$ curl -s http://localhost:4567/clients | jq .
+[
+  {
+    "name": "docs.sensu.io",
+    "address": "https://docs.sensu.io",
+    "playbook": "https://link-to-playbook.com",
+    "keepalives": false,
+    "version": "1.4.3",
+    "timestamp": 1534284314,
+    "subscriptions": [
+      "client:docs.sensu.io"
+    ]
+  }
+]
+```
+
+Nice work! You're now creating monitoring events with Sensu.
+In the next lesson, we'll act on these events by creating a pipeline.
+
+---
+
+## Lesson \#2: Pipe events into Slack
+
+Now that we know the sandbox is working properly, let's get to the fun stuff: creating a pipeline.
+In this lesson, we'll create a pipeline to send alerts to Slack.
+(If you'd rather not create a Slack account, you can skip ahead to [lesson 3](#lesson-3-automate-event-production-with-the-sensu-client).)
+
+**1. Install the Sensu Slack Plugins**
+
+Sensu Plugins are open-source collections of Sensu building blocks shared by the Sensu Community.
+In this lesson, we'll use the [Sensu Slack Plugins](https://github.com/sensu-plugins/sensu-plugins-slack) to create our pipeline.
+You can find this and more [Sensu Plugins on GitHub](https://github.com/sensu-plugins), or check out [Sensu Enterprise's built-in integrations](https://docs.sensu.io/sensu-enterprise/3.1/built-in-handlers).
+
+First we'll need to install the plugins:
+
+```
+sudo sensu-install -p sensu-plugins-slack
+```
+
+**2. Get your Slack webhook URL**
+
+If you're already an admin of a Slack, visit `https://YOUR WORKSPACE NAME HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+(If you're not yet a Slack admin, start [here](https://slack.com/get-started#create) to create a new workspace.)
+After saving, you'll see your webhook URL under Integration Settings.
+
+**3. Create a handler to send event data to Slack**
+
+To set up our Slack pipeline, we'll create a handler configuration file that points to the `handler-slack.rb` plugin and specifies your webhook URL:
+
+```
+sudo nano /etc/sensu/conf.d/handlers/slack.json
+```
+
+```json
+{
+  "handlers": {
+    "slack": {
+      "type": "pipe",
+      "command": "handler-slack.rb"
+    }
+  },
+  "slack": {
+    "webhook_url": "YOUR WEBHOOK URL HERE"
+  }
+}
+```
+
+To save and exit nano, `CTRL`+`X` then `Y` then `ENTER`.
+
+We'll need to restart the Sensu server and API whenever making changes to Sensu's configuration files.
+
+```
+sudo systemctl restart sensu-{server,api}
+```
+
+Then we can use the settings API to check that the Slack pipeline is in place:
+
+```
+curl -s http://localhost:4567/settings | jq .
+```
+
+```json
+$ curl -s http://localhost:4567/settings | jq .
+{
+  "...": "...",
+  "handlers": {
+    "slack": {
+      "type": "pipe",
+      "command": "handler-slack.rb"
+    }
+  },
+  "...": "...",
+  "slack": {
+    "webhook_url": "YOUR WEBHOOK URL HERE"
+  }
+}
+```
+
+**4. Pipe event data into Slack with the Sensu API**
+
+Let's use the results API to create an event and send it to our pipeline by adding `"handlers": ["slack"]`.
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Not great. The docs site took x.xxx seconds to load.",
+  "status": 1,
+  "handlers": ["slack"]
+}' \
+http://localhost:4567/results
+```
+
+Check out the Slack channel you configured when creating the webhook, and you should see a message from Sensu.
+
+Let's send another event to resolve the warning:
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Nice! The docs site took x.xxx seconds to load.",
+  "status": 0,
+  "handlers": ["slack"]
+}' \
+http://localhost:4567/results
+```
+
+**5. Add a production-only filter to the pipeline**
+
+This is great, but let's say we only really want to be notified by Slack when there's a critical alert.
+To do this, we'll create a filter using a configuration file:
+
+```
+sudo nano /etc/sensu/conf.d/filters/only_production.json
+```
+
+```
+{
+  "filters": {
+    "only_production": {
+      "attributes": {
+        "check": {
+          "environment": "production"
+        }
+      }
+    }
+  }
+}
+```
+
+This tells Sensu to check the event data (within the `check` scope) and only allow events with `"status": 2` to continue through the pipeline.
+
+But we're not done yet.
+Now we need to hook up the `only_production` filter to the pipeline.
+
+Open the `slack.json` handler configuration:
+
+```
+sudo nano /etc/sensu/conf.d/handlers/slack.json
+```
+
+And add a line with `"filters": ["only_production"],`, so it looks like:
+
+```
+{
+  "handlers": {
+    "slack": {
+      "filters": ["only_production"],
+      "type": "pipe",
+      "command": "handler-slack.rb"
+    }
+  },
+  "slack": {
+    "webhook_url": "https://hooks.slack.com/services/xxxxxxxx/xxxxxxxxxxx"
+  }
+}
+```
+
+Restart the Sensu server and API:
+
+```
+sudo systemctl restart sensu-{server,api}
+```
+
+Then we can use the settings API to see the filter we just created:
+
+```
+curl -s http://localhost:4567/settings | jq .
+```
+
+```
+$ curl -s http://localhost:4567/settings | jq .
+{
+  "...": "...",
+  "filters": {
+    "only_production": {
+      "attributes": {
+        "check": {
+          "status": 2
+        }
+      }
+    }
+  },
+  "...": "..."
+}
+```
+
+If you don't get a response from the API here, check for invalid JSON in `/etc/sensu/conf.d/handlers/slack.json`.
+
+**6. Send events to the filtered pipeline**
+
+Now Sensu will only pass production events through to Slack.
+Let's test it by sending a warning:
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Not great. The docs site took x.xxx seconds to load.",
+  "status": 1,
+  "handlers": ["slack"]
+}' \
+http://localhost:4567/results
+```
+
+We shouldn't see anything in Slack, but we should see an alert in the [dashboard events view](http://172.31.255.4:3000/#/events).
+
+Now let's create a production alert:
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Not great. The docs site took x.xxx seconds to load.",
+  "status": 1,
+  "environment": "production",
+  "handlers": ["slack"]
+}' \
+http://localhost:4567/results
+```
+
+And we should see it in Slack!
+You can customize your Slack messages using the [Sensu Slack Plugin handler attributes](https://github.com/sensu-plugins/sensu-plugins-slack#usage-for-handler-slackrb).
+
+Before we go, let's create a resolution event.
+
+```
+curl -s -XPOST -H 'Content-Type: application/json' \
+-d '{
+  "source": "docs.sensu.io",
+  "name": "check_curl_timings",
+  "output": "Nice! The docs site took x.xxx seconds to load.",
+  "status": 0,
+  "environment": "production",
+  "handlers": ["slack"]
+}' \
+http://localhost:4567/results
+```
+
+Great work. You've created your first Sensu pipeline!
+In the next lesson, we'll tap into the power of Sensu by adding a Sensu client to automate event production.
+
+---
+
+## Lesson \#3: Automate event production with the Sensu client
+So far we've used only the Sensu server and API, but in this lesson, we'll add the Sensu client and create a check to produce events automatically.
+Instead of sending alerts to Slack, we'll store event data with [InfluxDB](https://www.influxdata.com/) and visualize it with [Grafana](https://grafana.com/).
+
+**1. Install Nginx and the Sensu HTTP Plugin**
+
+Up until now we've used placeholder event data, but in this lesson, we'll use the [Sensu HTTP Plugin](https://github.com/sensu-plugins/sensu-plugins-http) to monitor an Nginx server running on the sandbox.
+
+First, install and start Nginx:
+
+```
+sudo yum install -y nginx && sudo systemctl start nginx
+```
+
+And make sure it's working with:
+
+```
+curl -I http://localhost:80
+```
+
+Then install the Sensu HTTP Plugin:
+
+```
+sudo sensu-install -p sensu-plugins-http
+```
+
+We'll be using the `metrics-curl.rb` plugin.
+We can test its output using:
+
+```
+/opt/sensu/embedded/bin/metrics-curl.rb localhost
+```
+
+```
+$ /opt/sensu/embedded/bin/metrics-curl.rb localhost
+...
+sensu-core-sandbox.curl_timings.http_code 200 1535670975
+```
+
+**2. Create an InfluxDB pipeline**
+
+Since we've already installed InfluxDB as part of the sandbox, all we need to do to create an InfluxDB pipeline is create a configuration file:
+
+```
+sudo nano /etc/sensu/conf.d/handlers/influx.json
+```
+
+```
+{
+  "handlers": {
+    "influx": {
+      "type": "tcp",
+      "socket": {
+        "host": "127.0.0.1",
+        "port": 2003
+      },
+      "mutator": "only_check_output"
+    }
+  }
+}
+```
+
+This tells Sensu to reduce event data to only the `output` and forward it a TCP socket.
+
+Now restart the Sensu server and API:
+
+```
+sudo systemctl restart sensu-{server,api}
+```
+
+And confirm using the settings API:
+
+```
+curl -s http://localhost:4567/settings | jq .
+```
+
+```
+$ curl -s http://localhost:4567/settings | jq .
+{
+  "...": "...",
+  "handlers": {
+    "slack": {
+      "filters": [
+        "only_production"
+      ],
+      "type": "pipe",
+      "command": "handler-slack.rb"
+    },
+    "influx": {
+      "type": "tcp",
+      "socket": {
+        "host": "127.0.0.1",
+        "port": 2003
+      },
+      "mutator": "only_check_output"
+    }
+  },
+  "...": "..."
+}
+```
+
+**3. Start the Sensu client**
+
+Now that we have our InfluxDB pipeline set up, let's start the Sensu client:
+
+```
+sudo systemctl start sensu-client
+```
+
+We can see the sandbox client start up using the clients API:
+
+```
+curl -s http://localhost:4567/clients | jq .
+```
+
+```json
+$ curl -s http://localhost:4567/clients | jq .
+[
+  {
+    "name": "sensu-core-sandbox",
+    "address": "10.0.2.15",
+    "subscriptions": [
+      "client:sensu-core-sandbox"
+    ],
+    "version": "1.4.3",
+    "timestamp": 1534284788
+  },
+  {"...": "..."}
+]
+```
+
+In the [dashboard client view](http://172.31.255.4:3000/#/clients), we can see that the client running in the sandbox is executing keepalive checks.
+
+_NOTE: The client gets its name from the `sensu.name` attribute configured as part of sandbox setup.
+You can change the client name using `sudo nano /etc/sensu/uchiwa.json`._
+
+**3. Add a client subscription**
+
+Clients run the set of checks defined by their `subscriptions`.
+Use a configuration file to assign our new client to run checks with the `sandbox-testing` subscription using `"subscriptions": ["sandbox-testing"]`:
+
+```
+sudo nano /etc/sensu/conf.d/client.json
+```
+
+```
+{
+  "client": {
+    "name": "sensu-core-sandbox",
+    "subscriptions": ["sandbox-testing"]
+  }
+}
+```
+
+Restart the Sensu client, server, and API:
+
+```
+sudo systemctl restart sensu-{client,server,api}
+```
+
+Then use the clients API to make sure the subscription is assigned to the client:
+
+```
+curl -s http://localhost:4567/clients | jq .
+```
+
+```
+$ curl -s http://localhost:4567/clients | jq .
+[
+  {
+    "name": "sensu-core-sandbox",
+    "address": "10.0.2.15",
+    "subscriptions": [
+      "client:sensu-core-sandbox",
+      "sandbox-testing"
+    ],
+    "version": "1.4.3",
+    "timestamp": 1534284788
+  },
+  {"...": "..."}
+]
+```
+
+If you don't see the new subscription, wait a few seconds and try the settings API again.
+
+**5. Create a check to monitor Nginx**
+
+Use a configuration file to create a service check that runs `metrics-curl.rb` every 10 seconds on all clients with the `sandbox-testing` subscription and send it to the InfluxDB pipeline:
+
+```
+sudo nano /etc/sensu/conf.d/checks/check_curl_timings.json
+```
+
+```
+{
+  "checks": {
+    "check_curl_timings": {
+      "command": "/opt/sensu/embedded/bin/metrics-curl.rb localhost",
+      "interval": 10,
+      "subscribers": ["sandbox-testing"],
+      "type": "metric",
+      "handlers": ["influx"]
+    }
+  }
+}
+```
+
+Note that `"type": "metric"` ensures that Sensu will handle every event, not just warning and critical alerts.
+
+Restart the Sensu client, server, and API:
+
+```
+sudo systemctl restart sensu-{client,server,api}
+```
+
+Use the settings API to make sure the check has been created:
+
+```
+curl -s http://localhost:4567/settings | jq .
+```
+
+```
+$ curl -s http://localhost:4567/settings | jq .
+{
+  "...": "...",
+  "checks": {
+    "check_curl_timings": {
+      "command": "/opt/sensu/embedded/bin/metrics-curl.rb localhost",
+      "interval": 10,
+      "subscribers": [
+        "sandbox-testing"
+      ],
+      "type": "metric",
+      "handlers": [
+        "influx"
+      ]
+    }
+  },
+  "...": "..."
+}
+```
+
+**6. See the HTTP response code events for Nginx in [Grafana](http://172.31.255.4:4000/d/core01/sensu-core-sandbox).**
+
+Log in to Grafana as username: `admin` password: `admin`.
+We should see a graph of real HTTP response codes for Nginx.
+
+Now if we turn Nginx off, we should see the impact in Grafana:
+
+```
+sudo systemctl stop nginx
+```
+
+Start Nginx:
+
+```
+sudo systemctl start nginx
+```
+
+**7. Automate disk usage monitoring for the sandbox**
+
+Now that we have a client and subscription set up, we can easily add more checks.
+For example, let's say we want to monitor disk usage on the sandbox.
+
+First, install the plugin:
+
+```
+sudo sensu-install -p sensu-plugins-disk-checks
+```
+
+And test it:
+
+```
+/opt/sensu/embedded/bin/metrics-disk-usage.rb
+```
+
+```
+$ /opt/sensu/embedded/bin/metrics-disk-usage.rb
+sensu-core-sandbox.disk_usage.root.used 2235 1534191189
+sensu-core-sandbox.disk_usage.root.avail 39714 1534191189
+...
+```
+
+Then create the check using a configuration file, assigning it to the `sandbox-testing` subscription and the InfluxDB pipeline:
+
+```
+sudo nano /etc/sensu/conf.d/checks/check_disk_usage.json
+```
+
+```
+{
+  "checks": {
+    "check_disk_usage": {
+      "command": "/opt/sensu/embedded/bin/metrics-disk-usage.rb",
+      "interval": 10,
+      "subscribers": ["sandbox-testing"],
+      "type": "metric",
+      "handlers": ["influx"]
+    }
+  }
+}
+```
+
+Finally, restart all the things:
+
+```
+sudo systemctl restart sensu-{client,server,api}
+```
+
+And we should see it working in the dashboard client view and via the settings API:
+
+```
+curl -s http://localhost:4567/settings | jq .
+```
+
+```
+$ curl -s http://localhost:4567/settings | jq .
+{
+  "...": "...",
+  "checks":
+    {"...": "..."},
+    "check_disk_usage": {
+      "command": "/opt/sensu/embedded/bin/metrics-disk-usage.rb",
+      "interval": 10,
+      "subscribers": [
+        "sandbox-testing"
+      ],
+      "type": "metric",
+      "handlers": [
+        "influx"
+      ]
+    }
+  },
+  "...": "..."
+}
+```
+
+Now we should be able to see disk usage metrics for the sandbox in [Grafana](http://172.31.255.4:4000/d/core02/sensu-core-sandbox-combined).
+
+You made it! You're ready for the next level of Sensu-ing.
+Here are some resources to help continue your journey:
+
+- [Install Sensu with configuration management](https://docs.sensu.io/sensu-core/latest/installation/configuration-management/)
+- [Create application events using the client socket](https://docs.sensu.io/sensu-core/latest/reference/clients/#what-is-the-sensu-client-socket)
+
+## Appendix: Sandbox Architecture
+
+The Sensu Core sandbox is a CentOS 7 virtual machine managed with Vagrant and VirtualBox.
+It is intended for use as a learning tool. We do not recommend this tool as part of a production installation.
+To install Sensu in production, please see the [installation guide](https://docs.sensu.io/sensu-core/latest/installation/overview/).
+
+### Sandbox contents
+
+![sandbox-core 3](https://user-images.githubusercontent.com/11339965/45131333-557c4c00-b141-11e8-83db-6e1ba4edcf1e.png)

--- a/sensu-classic/core/Vagrantfile
+++ b/sensu-classic/core/Vagrantfile
@@ -1,0 +1,10 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-7.4"
+  config.vm.hostname = "sensu-core-sandbox"
+  config.vm.network "private_network", ip: "172.31.255.4"
+  config.vm.provision "shell", path: "sensu-and-influx.sh"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 2048
+    vb.cpus = 2
+  end
+end

--- a/sensu-classic/core/files/grafana/dashboard-disk.json
+++ b/sensu-classic/core/files/grafana/dashboard-disk.json
@@ -1,0 +1,319 @@
+{
+  "dashboard": 
+
+{
+  "__inputs": [
+    {
+      "name": "InfluxDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "sensu-core-sandbox.curl_timings.http_code",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Nginx HTTP Response Codes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "sensu-core-sandbox.disk_usage.root.boot.used_percentage",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Sandbox Disk Usage %",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Sensu Core Sandbox Combined",
+  "uid": "core02",
+  "version": 5
+}
+}

--- a/sensu-classic/core/files/grafana/dashboard-http.json
+++ b/sensu-classic/core/files/grafana/dashboard-http.json
@@ -1,0 +1,207 @@
+{
+  "dashboard": 
+
+{
+  "__inputs": [
+    {
+      "name": "InfluxDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "InfluxDB",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "sensu-core-sandbox.curl_timings.http_code",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Nginx HTTP Response Codes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Sensu Core Sandbox",
+  "uid": "core01",
+  "version": 5
+}
+}

--- a/sensu-classic/core/files/grafana/provisioning/datasources/influxdb.yaml
+++ b/sensu-classic/core/files/grafana/provisioning/datasources/influxdb.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: 1
+
+deleteDatasources:
+  - name: InfluxDB
+    orgId: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    orgId: 1
+    database: sensu
+    user: grafana
+    password: grafana
+    url: http://localhost:8086

--- a/sensu-classic/core/files/influxdb/influxdb.conf
+++ b/sensu-classic/core/files/influxdb/influxdb.conf
@@ -1,0 +1,557 @@
+### Welcome to the InfluxDB configuration file.
+
+# The values in this file override the default values used by the system if
+# a config option is not specified. The commented out lines are the configuration
+# field and the default value used. Uncommenting a line and changing the value
+# will change the value used at runtime when the process is restarted.
+
+# Once every 24 hours InfluxDB will report usage data to usage.influxdata.com
+# The data includes a random ID, os, arch, version, the number of series and other
+# usage data. No data from user databases is ever transmitted.
+# Change this option to true to disable reporting.
+# reporting-disabled = false
+
+# Bind address to use for the RPC service for backup and restore.
+# bind-address = "127.0.0.1:8088"
+
+###
+### [meta]
+###
+### Controls the parameters for the Raft consensus group that stores metadata
+### about the InfluxDB cluster.
+###
+
+[meta]
+  # Where the metadata/raft database is stored
+  dir = "/var/lib/influxdb/meta"
+
+  # Automatically create a default retention policy when creating a database.
+  # retention-autocreate = true
+
+  # If log messages are printed for the meta service
+  # logging-enabled = true
+
+###
+### [data]
+###
+### Controls where the actual shard data for InfluxDB lives and how it is
+### flushed from the WAL. "dir" may need to be changed to a suitable place
+### for your system, but the WAL settings are an advanced configuration. The
+### defaults should work for most systems.
+###
+
+[data]
+  # The directory where the TSM storage engine stores TSM files.
+  dir = "/var/lib/influxdb/data"
+
+  # The directory where the TSM storage engine stores WAL files.
+  wal-dir = "/var/lib/influxdb/wal"
+
+  # The amount of time that a write will wait before fsyncing.  A duration
+  # greater than 0 can be used to batch up multiple fsync calls.  This is useful for slower
+  # disks or when WAL write contention is seen.  A value of 0s fsyncs every write to the WAL.
+  # Values in the range of 0-100ms are recommended for non-SSD disks.
+  # wal-fsync-delay = "0s"
+
+
+  # The type of shard index to use for new shards.  The default is an in-memory index that is
+  # recreated at startup.  A value of "tsi1" will use a disk based index that supports higher
+  # cardinality datasets.
+  # index-version = "inmem"
+
+  # Trace logging provides more verbose output around the tsm engine. Turning
+  # this on can provide more useful output for debugging tsm engine issues.
+  # trace-logging-enabled = false
+
+  # Whether queries should be logged before execution. Very useful for troubleshooting, but will
+  # log any sensitive data contained within a query.
+  # query-log-enabled = true
+
+  # Settings for the TSM engine
+
+  # CacheMaxMemorySize is the maximum size a shard's cache can
+  # reach before it starts rejecting writes.
+  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
+  # Values without a size suffix are in bytes.
+  # cache-max-memory-size = "1g"
+
+  # CacheSnapshotMemorySize is the size at which the engine will
+  # snapshot the cache and write it to a TSM file, freeing up memory
+  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
+  # Values without a size suffix are in bytes.
+  # cache-snapshot-memory-size = "25m"
+
+  # CacheSnapshotWriteColdDuration is the length of time at
+  # which the engine will snapshot the cache and write it to
+  # a new TSM file if the shard hasn't received writes or deletes
+  # cache-snapshot-write-cold-duration = "10m"
+
+  # CompactFullWriteColdDuration is the duration at which the engine
+  # will compact all TSM files in a shard if it hasn't received a
+  # write or delete
+  # compact-full-write-cold-duration = "4h"
+
+  # The maximum number of concurrent full and level compactions that can run at one time.  A
+  # value of 0 results in 50% of runtime.GOMAXPROCS(0) used at runtime.  Any number greater
+  # than 0 limits compactions to that value.  This setting does not apply
+  # to cache snapshotting.
+  # max-concurrent-compactions = 0
+
+  # The threshold, in bytes, when an index write-ahead log file will compact
+  # into an index file. Lower sizes will cause log files to be compacted more
+  # quickly and result in lower heap usage at the expense of write throughput.
+  # Higher sizes will be compacted less frequently, store more series in-memory,
+  # and provide higher write throughput.
+  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
+  # Values without a size suffix are in bytes.
+  # max-index-log-file-size = "1m"
+
+  # The maximum series allowed per database before writes are dropped.  This limit can prevent
+  # high cardinality issues at the database level.  This limit can be disabled by setting it to
+  # 0.
+  # max-series-per-database = 1000000
+
+  # The maximum number of tag values per tag that are allowed before writes are dropped.  This limit
+  # can prevent high cardinality tag values from being written to a measurement.  This limit can be
+  # disabled by setting it to 0.
+  # max-values-per-tag = 100000
+
+  # If true, then the mmap advise value MADV_WILLNEED will be provided to the kernel with respect to
+  # TSM files. This setting has been found to be problematic on some kernels, and defaults to off.
+  # It might help users who have slow disks in some cases.
+  # tsm-use-madv-willneed = false
+
+###
+### [coordinator]
+###
+### Controls the clustering service configuration.
+###
+
+[coordinator]
+  # The default time a write request will wait until a "timeout" error is returned to the caller.
+  # write-timeout = "10s"
+
+  # The maximum number of concurrent queries allowed to be executing at one time.  If a query is
+  # executed and exceeds this limit, an error is returned to the caller.  This limit can be disabled
+  # by setting it to 0.
+  # max-concurrent-queries = 0
+
+  # The maximum time a query will is allowed to execute before being killed by the system.  This limit
+  # can help prevent run away queries.  Setting the value to 0 disables the limit.
+  # query-timeout = "0s"
+
+  # The time threshold when a query will be logged as a slow query.  This limit can be set to help
+  # discover slow or resource intensive queries.  Setting the value to 0 disables the slow query logging.
+  # log-queries-after = "0s"
+
+  # The maximum number of points a SELECT can process.  A value of 0 will make
+  # the maximum point count unlimited.  This will only be checked every second so queries will not
+  # be aborted immediately when hitting the limit.
+  # max-select-point = 0
+
+  # The maximum number of series a SELECT can run.  A value of 0 will make the maximum series
+  # count unlimited.
+  # max-select-series = 0
+
+  # The maxium number of group by time bucket a SELECT can create.  A value of zero will max the maximum
+  # number of buckets unlimited.
+  # max-select-buckets = 0
+
+###
+### [retention]
+###
+### Controls the enforcement of retention policies for evicting old data.
+###
+
+[retention]
+  # Determines whether retention policy enforcement enabled.
+  # enabled = true
+
+  # The interval of time when retention policy enforcement checks run.
+  # check-interval = "30m"
+
+###
+### [shard-precreation]
+###
+### Controls the precreation of shards, so they are available before data arrives.
+### Only shards that, after creation, will have both a start- and end-time in the
+### future, will ever be created. Shards are never precreated that would be wholly
+### or partially in the past.
+
+[shard-precreation]
+  # Determines whether shard pre-creation service is enabled.
+  # enabled = true
+
+  # The interval of time when the check to pre-create new shards runs.
+  # check-interval = "10m"
+
+  # The default period ahead of the endtime of a shard group that its successor
+  # group is created.
+  # advance-period = "30m"
+
+###
+### Controls the system self-monitoring, statistics and diagnostics.
+###
+### The internal database for monitoring data is created automatically if
+### if it does not already exist. The target retention within this database
+### is called 'monitor' and is also created with a retention period of 7 days
+### and a replication factor of 1, if it does not exist. In all cases the
+### this retention policy is configured as the default for the database.
+
+[monitor]
+  # Whether to record statistics internally.
+  # store-enabled = true
+
+  # The destination database for recorded statistics
+  # store-database = "_internal"
+
+  # The interval at which to record statistics
+  # store-interval = "10s"
+
+###
+### [http]
+###
+### Controls how the HTTP endpoints are configured. These are the primary
+### mechanism for getting data into and out of InfluxDB.
+###
+
+[http]
+  # Determines whether HTTP endpoint is enabled.
+  # enabled = true
+
+  # The bind address used by the HTTP service.
+  # bind-address = ":8086"
+
+  # Determines whether user authentication is enabled over HTTP/HTTPS.
+  # auth-enabled = false
+
+  # The default realm sent back when issuing a basic auth challenge.
+  # realm = "InfluxDB"
+
+  # Determines whether HTTP request logging is enabled.
+  # log-enabled = true
+
+  # Determines whether the HTTP write request logs should be suppressed when the log is enabled.
+  # suppress-write-log = false
+
+  # When HTTP request logging is enabled, this option specifies the path where
+  # log entries should be written. If unspecified, the default is to write to stderr, which
+  # intermingles HTTP logs with internal InfluxDB logging.
+  #
+  # If influxd is unable to access the specified path, it will log an error and fall back to writing
+  # the request log to stderr.
+  # access-log-path = ""
+
+  # Determines whether detailed write logging is enabled.
+  # write-tracing = false
+
+  # Determines whether the pprof endpoint is enabled.  This endpoint is used for
+  # troubleshooting and monitoring.
+  # pprof-enabled = true
+
+  # Enables a pprof endpoint that binds to localhost:6060 immediately on startup.
+  # This is only needed to debug startup issues.
+  # debug-pprof-enabled = false
+
+  # Determines whether HTTPS is enabled.
+  # https-enabled = false
+
+  # The SSL certificate to use when HTTPS is enabled.
+  # https-certificate = "/etc/ssl/influxdb.pem"
+
+  # Use a separate private key location.
+  # https-private-key = ""
+
+  # The JWT auth shared secret to validate requests using JSON web tokens.
+  # shared-secret = ""
+
+  # The default chunk size for result sets that should be chunked.
+  # max-row-limit = 0
+
+  # The maximum number of HTTP connections that may be open at once.  New connections that
+  # would exceed this limit are dropped.  Setting this value to 0 disables the limit.
+  # max-connection-limit = 0
+
+  # Enable http service over unix domain socket
+  # unix-socket-enabled = false
+
+  # The path of the unix domain socket.
+  # bind-socket = "/var/run/influxdb.sock"
+
+  # The maximum size of a client request body, in bytes. Setting this value to 0 disables the limit.
+  # max-body-size = 25000000
+
+  # The maximum number of writes processed concurrently.
+  # Setting this to 0 disables the limit.
+  # max-concurrent-write-limit = 0
+
+  # The maximum number of writes queued for processing.
+  # Setting this to 0 disables the limit.
+  # max-enqueued-write-limit = 0
+
+  # The maximum duration for a write to wait in the queue to be processed.
+  # Setting this to 0 or setting max-concurrent-write-limit to 0 disables the limit.
+  # enqueued-write-timeout = 0
+
+
+###
+### [ifql]
+###
+### Configures the ifql RPC API.
+###
+
+[ifql]
+  # Determines whether the RPC service is enabled.
+  # enabled = true
+
+  # Determines whether additional logging is enabled.
+  # log-enabled = true
+
+  # The bind address used by the ifql RPC service.
+  # bind-address = ":8082"
+
+
+###
+### [logging]
+###
+### Controls how the logger emits logs to the output.
+###
+
+[logging]
+  # Determines which log encoder to use for logs. Available options
+  # are auto, logfmt, and json. auto will use a more a more user-friendly
+  # output format if the output terminal is a TTY, but the format is not as
+  # easily machine-readable. When the output is a non-TTY, auto will use
+  # logfmt.
+  # format = "auto"
+
+  # Determines which level of logs will be emitted. The available levels
+  # are error, warn, info, and debug. Logs that are equal to or above the
+  # specified level will be emitted.
+  # level = "info"
+
+  # Suppresses the logo output that is printed when the program is started.
+  # The logo is always suppressed if STDOUT is not a TTY.
+  # suppress-logo = false
+
+###
+### [subscriber]
+###
+### Controls the subscriptions, which can be used to fork a copy of all data
+### received by the InfluxDB host.
+###
+
+[subscriber]
+  # Determines whether the subscriber service is enabled.
+  # enabled = true
+
+  # The default timeout for HTTP writes to subscribers.
+  # http-timeout = "30s"
+
+  # Allows insecure HTTPS connections to subscribers.  This is useful when testing with self-
+  # signed certificates.
+  # insecure-skip-verify = false
+
+  # The path to the PEM encoded CA certs file. If the empty string, the default system certs will be used
+  # ca-certs = ""
+
+  # The number of writer goroutines processing the write channel.
+  # write-concurrency = 40
+
+  # The number of in-flight writes buffered in the write channel.
+  # write-buffer-size = 1000
+
+
+###
+### [[graphite]]
+###
+### Controls one or many listeners for Graphite data.
+###
+
+[[graphite]]
+  # Determines whether the graphite endpoint is enabled.
+ enabled = true
+ database = "sensu"
+  # retention-policy = ""
+  # bind-address = ":2003"
+  # protocol = "tcp"
+  # consistency-level = "one"
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # Flush if this many points get buffered
+  # batch-size = 5000
+
+  # number of batches that may be pending in memory
+  # batch-pending = 10
+
+  # Flush at least this often even if we haven't hit buffer limit
+  # batch-timeout = "1s"
+
+  # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+  # udp-read-buffer = 0
+
+  ### This string joins multiple matching 'measurement' values providing more control over the final measurement name.
+  # separator = "."
+
+  ### Default tags that will be added to all metrics.  These can be overridden at the template level
+  ### or by tags extracted from metric
+  # tags = ["region=us-east", "zone=1c"]
+
+  ### Each template line requires a template pattern.  It can have an optional
+  ### filter before the template and separated by spaces.  It can also have optional extra
+  ### tags following the template.  Multiple tags should be separated by commas and no spaces
+  ### similar to the line protocol format.  There can be only one default template.
+  # templates = [
+  #   "*.app env.service.resource.measurement",
+  #   # Default template
+  #   "server.*",
+  # ]
+
+###
+### [collectd]
+###
+### Controls one or many listeners for collectd data.
+###
+
+[[collectd]]
+  # enabled = false
+  # bind-address = ":25826"
+  # database = "collectd"
+  # retention-policy = ""
+  #
+  # The collectd service supports either scanning a directory for multiple types
+  # db files, or specifying a single db file.
+  # typesdb = "/usr/local/share/collectd"
+  #
+  # security-level = "none"
+  # auth-file = "/etc/collectd/auth_file"
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # Flush if this many points get buffered
+  # batch-size = 5000
+
+  # Number of batches that may be pending in memory
+  # batch-pending = 10
+
+  # Flush at least this often even if we haven't hit buffer limit
+  # batch-timeout = "10s"
+
+  # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+  # read-buffer = 0
+
+  # Multi-value plugins can be handled two ways.
+  # "split" will parse and store the multi-value plugin data into separate measurements
+  # "join" will parse and store the multi-value plugin as a single multi-value measurement.
+  # "split" is the default behavior for backward compatability with previous versions of influxdb.
+  # parse-multivalue-plugin = "split"
+###
+### [opentsdb]
+###
+### Controls one or many listeners for OpenTSDB data.
+###
+
+[[opentsdb]]
+  # enabled = false
+  # bind-address = ":4242"
+  # database = "opentsdb"
+  # retention-policy = ""
+  # consistency-level = "one"
+  # tls-enabled = false
+  # certificate= "/etc/ssl/influxdb.pem"
+
+  # Log an error for every malformed point.
+  # log-point-errors = true
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Only points
+  # metrics received over the telnet protocol undergo batching.
+
+  # Flush if this many points get buffered
+  # batch-size = 1000
+
+  # Number of batches that may be pending in memory
+  # batch-pending = 5
+
+  # Flush at least this often even if we haven't hit buffer limit
+  # batch-timeout = "1s"
+
+###
+### [[udp]]
+###
+### Controls the listeners for InfluxDB line protocol data via UDP.
+###
+
+[[udp]]
+  # enabled = false
+  # bind-address = ":8089"
+  # database = "udp"
+  # retention-policy = ""
+
+  # InfluxDB precision for timestamps on received points ("" or "n", "u", "ms", "s", "m", "h")
+  # precision = ""
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # Flush if this many points get buffered
+  # batch-size = 5000
+
+  # Number of batches that may be pending in memory
+  # batch-pending = 10
+
+  # Will flush at least this often even if we haven't hit buffer limit
+  # batch-timeout = "1s"
+
+  # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+  # read-buffer = 0
+
+###
+### [continuous_queries]
+###
+### Controls how continuous queries are run within InfluxDB.
+###
+
+[continuous_queries]
+  # Determines whether the continuous query service is enabled.
+  # enabled = true
+
+  # Controls whether queries are logged when executed by the CQ service.
+  # log-enabled = true
+
+  # Controls whether queries are logged to the self-monitoring data store.
+  # query-stats-enabled = false
+
+  # interval for how often continuous queries will be checked if they need to run
+  # run-interval = "1s"
+
+###
+### [tls]
+###
+### Global configuration settings for TLS in InfluxDB.
+###
+
+[tls]
+  # Determines the available set of cipher suites. See https://golang.org/pkg/crypto/tls/#pkg-constants
+  # for a list of available ciphers, which depends on the version of Go (use the query
+  # SHOW DIAGNOSTICS to see the version of Go used to build InfluxDB). If not specified, uses
+  # the default settings from Go's crypto/tls package.
+  # ciphers = [
+  #   "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+  #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+  # ]
+
+  # Minimum version of the tls protocol that will be negotiated. If not specified, uses the
+  # default settings from Go's crypto/tls package.
+  # min-version = "tls1.2"
+
+  # Maximum version of the tls protocol that will be negotiated. If not specified, uses the
+  # default settings from Go's crypto/tls package.
+  # max-version = "tls1.2"
+  

--- a/sensu-classic/core/sensu-and-influx.sh
+++ b/sensu-classic/core/sensu-and-influx.sh
@@ -1,0 +1,159 @@
+############################################
+#            Sensu Core Sandbox            #
+############################################
+#              !!!WARNING!!!               #
+#         NOT FOR PRODUCTION USE           #
+############################################
+
+#!/bin/sh
+IPADDR=$(/sbin/ip -o -4 addr list enp0s8  | awk '{print $4}' | cut -d/ -f1)
+
+# Make sure we have all the package repos we need!
+sudo yum install epel-release nano vi yum-utils openssl httpd -y
+sudo yum groupinstall 'Development Tools' -y
+
+# Set up zero-dependency erlang
+echo ' [rabbitmq-erlang]
+name=rabbitmq-erlang
+baseurl=https://dl.bintray.com/rabbitmq/rpm/erlang/20/el/7
+gpgcheck=1
+gpgkey=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+repo_gpgcheck=0
+enabled=1' | sudo tee /etc/yum.repos.d/rabbitmq-erlang.repo
+sudo yum install erlang -y
+
+# Install rabbitmq
+sudo yum install https://dl.bintray.com/rabbitmq/rabbitmq-server-rpm/rabbitmq-server-3.6.12-1.el7.noarch.rpm -y
+
+# Set up Sensu's repository
+echo '[sensu]
+name=sensu
+baseurl="https://repositories.sensuapp.org/yum/$releasever/$basearch/"
+gpgcheck=0
+enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
+
+# Add the InfluxDB YUM repository
+echo '[influxdb]
+name = InfluxDB Repository - RHEL $releasever
+baseurl = https://repos.influxdata.com/rhel/$releasever/$basearch/stable
+enabled = 1
+gpgcheck = 1
+gpgkey = https://repos.influxdata.com/influxdb.key' | tee /etc/yum.repos.d/influxdb.repo
+
+# Add the Grafana YUM repository
+echo '[grafana]
+name=grafana
+baseurl=https://packagecloud.io/grafana/stable/el/7/$basearch
+repo_gpgcheck=1
+enabled=1
+gpgcheck=1
+gpgkey=https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt' | tee /etc/yum.repos.d/grafana.repo
+
+# Install Redis
+sudo yum install redis influxdb grafana -y
+systemctl stop firewalld
+systemctl disable firewalld
+
+# Install Sensu and Uchiwa
+sudo yum install sensu uchiwa -y
+
+# Provide minimal transport configuration (used by client, server and API)
+echo '{
+  "transport": {
+    "name": "rabbitmq"
+  }
+}' | sudo tee /etc/sensu/transport.json
+
+# Move Grafana to port 4000
+sed -i 's/^;http_port = 3000/http_port = 4000/' /etc/grafana/grafana.ini
+
+# Ensure config file permissions are correct and set up Grafana configuration
+sudo chown -R sensu:sensu /etc/sensu
+cp -r /vagrant/files/grafana/* /etc/grafana/
+chown -R grafana:grafana /etc/grafana
+
+# Set up InfluxDB configuration to enable Graphite API endpoint
+rm /etc/influxdb/influxdb.conf
+cp /vagrant/files/influxdb/influxdb.conf /etc/influxdb/influxdb.conf
+
+# Install more tools
+sudo yum install curl jq -y
+
+# Provide Minimal uchiwa conifguration, pointing at API on localhost
+
+echo '{
+  "sensu": [
+    {
+      "name": "sensu-core-sandbox",
+      "host": "127.0.0.1",
+      "port": 4567
+    }
+  ],
+  "uchiwa": {
+    "host": "0.0.0.0",
+    "port": 3000
+  }
+ }' |sudo tee /etc/sensu/uchiwa.json
+
+# Configure Sensu to use rabbitmq
+
+echo '{
+  "rabbitmq": {
+    "host": "127.0.0.1",
+    "port": 5672,
+    "vhost": "/sensu",
+    "user": "sensu",
+    "password": "secret",
+    "heartbeat": 30,
+    "prefetch": 50
+  }
+}' | sudo tee /etc/sensu/conf.d/rabbitmq.json
+
+# Configure minimal Redis configuration for Sensu
+
+echo '{
+  "redis": {
+    "host": "127.0.0.1",
+    "port": 6379
+  }
+}' | sudo tee /etc/sensu/conf.d/redis.json
+
+# Start up rabbitmq services
+sudo systemctl start rabbitmq-server
+
+# Add rabbitmq vhost configurations
+sudo rabbitmqctl add_vhost /sensu
+sudo rabbitmqctl add_user sensu secret
+sudo rabbitmqctl set_permissions -p /sensu sensu ".*" ".*" ".*"
+
+# Going to do some general setup stuff
+cd /etc/sensu/conf.d
+mkdir {checks,filters,mutators,handlers,templates}
+
+#Start up other services
+sudo systemctl start sensu-{server,api}.service
+sudo systemctl start redis.service
+sudo systemctl start uchiwa
+sudo systemctl enable uchiwa
+sudo systemctl enable redis.service
+sudo systemctl enable rabbitmq-server
+sudo systemctl enable sensu-{server,api}.service
+systemctl start influxdb
+chkconfig influxdb on
+systemctl start grafana-server
+systemctl enable grafana-server.service
+
+# Create the InfluxDB database
+influx -execute "CREATE DATABASE sensu;"
+
+# Create two Grafana dashboards
+curl -XPOST -H 'Content-Type: application/json' -d@/vagrant/files/grafana/dashboard-http.json HTTP://admin:admin@127.0.0.1:4000/api/dashboards/db
+curl -XPOST -H 'Content-Type: application/json' -d@/vagrant/files/grafana/dashboard-disk.json HTTP://admin:admin@127.0.0.1:4000/api/dashboards/db
+
+echo -e "=================
+Sensu is now up and running!
+Access the dashboard at $IPADDR:3000
+Access Grafana at $IPADDR:4000
+================="


### PR DESCRIPTION
This tutorial is meant to introduce new users to Sensu as the monitoring event pipeline and replace the existing Five Minute Installation guide. It is based heavily off [Aaron's Intro to Sensu workshop](https://github.com/sensu/training-vagrant/tree/master/workshops/intro-to-sensu) with elements borrowed from [Caleb's Enterprise Workshop](https://github.com/sensu/sensu-enterprise-workshop). Thanks to Cameron for troubleshooting support and Anna, Jordan, Edgar, and Richie for help with testing.