### PR TITLE
Update to use assets with sensu docs change

### DIFF
--- a/sensu-go/files/influx-handler.json
+++ b/sensu-go/files/influx-handler.json
@@ -17,8 +17,6 @@
       "INFLUXDB_USER=sensu",
       "INFLUXDB_PASS=sandbox"
     ],
-    "runtime_assets": [
-      "influx-handler"
-    ]
+    "runtime_assets": []
   }
 }

--- a/sensu-go/files/influx-handler.json
+++ b/sensu-go/files/influx-handler.json
@@ -8,7 +8,7 @@
       "annotations": null
     },
     "type": "pipe",
-    "command": "/usr/local/bin/sensu-influxdb-handler --db-name 'sensu'",
+    "command": "sensu-influxdb-handler --db-name 'sensu'",
     "timeout": 0,
     "handlers": [],
     "filters": [],
@@ -17,6 +17,8 @@
       "INFLUXDB_USER=sensu",
       "INFLUXDB_PASS=sandbox"
     ],
-    "runtime_assets": []
+    "runtime_assets": [
+      "influx-handler"
+    ]
   }
 }

--- a/sensu-go/files/sensu-slack-handler.json
+++ b/sensu-go/files/sensu-slack-handler.json
@@ -8,7 +8,7 @@
       "annotations": null
     },
     "type": "pipe",
-    "command": "/usr/local/bin/sensu-slack-handler -c \"${KEEPALIVE_SLACK_CHANNEL}\" -w \"${KEEPALIVE_SLACK_WEBHOOK}\"",
+    "command": "sensu-slack-handler -c \"${KEEPALIVE_SLACK_CHANNEL}\" -w \"${KEEPALIVE_SLACK_WEBHOOK}\"",
     "timeout": 0,
     "handlers": [],
     "filters": [],

--- a/sensu-go/provision/setup.sh
+++ b/sensu-go/provision/setup.sh
@@ -159,15 +159,15 @@ rm /etc/influxdb/influxdb.conf
 cp /vagrant_files/etc/influxdb/influxdb.conf /etc/influxdb/influxdb.conf
 
 
-## Install Sensu Go Slack Handler
-wget -q -nc https://github.com/sensu/sensu-slack-handler/releases/download/1.0.0/sensu-slack-handler_1.0.0_linux_amd64.tar.gz -P /tmp/
-tar xvzf /tmp/sensu-slack-handler_1.0.0_linux_amd64.tar.gz -C /tmp/
-cp /tmp/bin/sensu-slack-handler /usr/local/bin/
+# ## Install Sensu Go Slack Handler
+# wget -q -nc https://github.com/sensu/sensu-slack-handler/releases/download/1.0.0/sensu-slack-handler_1.0.0_linux_amd64.tar.gz -P /tmp/
+# tar xvzf /tmp/sensu-slack-handler_1.0.0_linux_amd64.tar.gz -C /tmp/
+# cp /tmp/bin/sensu-slack-handler /usr/local/bin/
 
-## Install Sensu Go InfluxDB Handler
-wget -q -nc https://github.com/sensu/sensu-influxdb-handler/releases/download/3.0.1/sensu-influxdb-handler_3.0.1_linux_amd64.tar.gz -P /tmp/
-tar xvzf /tmp/sensu-influxdb-handler_3.0.1_linux_amd64.tar.gz -C /tmp/
-cp /tmp/bin/sensu-influxdb-handler /usr/local/bin/
+# ## Install Sensu Go InfluxDB Handler
+# wget -q -nc https://github.com/sensu/sensu-influxdb-handler/releases/download/3.1.2/sensu-influxdb-handler_3.1.2_linux_amd64.tar.gz -P /tmp/
+# tar xvzf /tmp/sensu-influxdb-handler_3.1.2_linux_amd64.tar.gz -C /tmp/
+# cp /tmp/bin/sensu-influxdb-handler /usr/local/bin/
 
 
 ### Install the metrics-curl.rb check


### PR DESCRIPTION
In https://github.com/sensu/sensu-docs/pull/1248 we are going to use assets in the lesson. This means the setup script no longer needs to download the handlers and stage them for use later. It also means that the slack and influxdb handler commands will change to use whatever PATH sensu provides them to find the assets.

I tested this and it works with the current condition of the above PR, with my added suggestions.

This PR may change based on any discussion coming from using full resource definitions vs using `sensuctl create` in some of the sandbox lesson on the documentation site.