### PR TITLE
Specify Sensu version 5.16.1

### DIFF
--- a/sensu-go-docker/docker-compose.yml
+++ b/sensu-go-docker/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:latest
+    image: sensu/sensu:5.16.1
     ports:
     - 3000:3000
     - 8080:8080


### PR DESCRIPTION
@nixwiz identified an [issue](https://mail.google.com/mail/u/0/#inbox/FMfcgxwGDDgZGJfqMmdHTkLTsnWjCGCR) that prevents step 4 in our "Learn Sensu in 15 minutes" from working properly. The check in step 4 requires assets that don't unarchive properly in the latest version of Sensu Go.

Eng is working on it but until it's fixed, I would like to specify version 5.16.1 here so that our Katacoda scenarios will work properly. I can change it back to latest when the issue is resolved. What do you think? 