### PR TITLE
Specify sensu version "latest"

### DIFF
--- a/sensu-go-docker/docker-compose.yml
+++ b/sensu-go-docker/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   sensu-backend:
-    image: sensu/sensu:5.16.1
+    image: sensu/sensu:latest
     ports:
     - 3000:3000
     - 8080:8080


### PR DESCRIPTION
Restores docker compose file to use "latest" rather than "5.16.1"

Undoes https://github.com/sensu/sandbox/pull/68